### PR TITLE
Update xdpdump_bpf.c

### DIFF
--- a/xdp-dump/xdpdump_bpf.c
+++ b/xdp-dump/xdpdump_bpf.c
@@ -67,8 +67,7 @@ static inline void trace_to_perf_buffer(struct xdp_buff *xdp, bool fexit,
 	void *data = (void *)(long)xdp->data;
 	struct pkt_trace_metadata metadata;
 
-	if (data >= data_end ||
-	    trace_cfg.capture_if_ifindex != xdp->rxq->dev->ifindex)
+	if (data >= data_end)
 		return;
 
 	metadata.prog_index = trace_cfg.capture_prog_index;


### PR DESCRIPTION
The original code included a check that compared the incoming packet's interface index (xdp->rxq->dev->ifindex) with a configured interface index (trace_cfg.capture_if_ifindex). This logic fails when XDP is attached to a master interface, but packets arrive on a slave interface (e.g., in bonding or teaming setups). In such cases, the interface index check causes valid packets to be skipped. The patch packets from slave interfaces to be processed correctly when XDP is attached to the master.